### PR TITLE
Move API types to shared

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,7 @@
 // Zod - NPM - This works best with the AI SDK. Other's cause versioning issues.
 export { z } from 'zod';
+export type { ZodFormattedError, typeToFlattenedError } from 'zod';
 
 // MongoDB - NPM
 export { ObjectId } from 'mongodb';
+export type { InsertOneResult, OptionalId } from 'mongodb';

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 // Zod - NPM - This works best with the AI SDK. Other's cause versioning issues.
 export { z } from 'zod';
-export type { ZodFormattedError, typeToFlattenedError } from 'zod';
+export type { typeToFlattenedError, ZodFormattedError } from 'zod';
 
 // MongoDB - NPM
 export { ObjectId } from 'mongodb';

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,57 @@
+import { ErrorResponse } from './general.service.ts';
+import { SafeUser, UserInDB } from '../models/user.model.ts';
+import {
+  InsertOneResult,
+  OptionalId,
+  typeToFlattenedError,
+} from '../../deps.ts';
+
+// me
+
+export type MeSuccessResponse = {
+  message: string;
+  user: SafeUser;
+};
+
+export type MeResponse = MeSuccessResponse | ErrorResponse;
+
+// login
+
+export type LoginSuccessResponse = {
+  token: string;
+};
+
+export type LoginErrorDetails = typeToFlattenedError<{
+  username: string;
+  password: string;
+}, string>;
+
+export type LoginErrorResponse = {
+  errors: LoginErrorDetails;
+};
+
+export type LoginResponse =
+  | LoginSuccessResponse
+  | LoginErrorResponse
+  | ErrorResponse;
+
+// signup
+
+export type SignupSuccessResponse = InsertOneResult<OptionalId<UserInDB>>;
+
+export type SignupErrorDetails = typeToFlattenedError<{
+  password: string;
+  email: string;
+  username: string;
+  name_first?: string | undefined;
+  name_last?: string | undefined;
+}, string>;
+
+export type SignupErrorResponse = {
+  errors: SignupErrorDetails;
+};
+
+export type SignupResponse =
+  | SignupSuccessResponse
+  | SignupErrorResponse
+  | ErrorResponse;

--- a/src/services/events.service.ts
+++ b/src/services/events.service.ts
@@ -9,7 +9,7 @@ export type GetAllEventsSuccessResponse = Event[];
 
 export type GetAllEventsErrorResponse = {
   error: string;
-  details: ZodFormattedError<{ mode?: EventMode}> | undefined;
+  details: ZodFormattedError<{ mode?: EventMode }> | undefined;
 };
 
 export type GetAllEventsResponse =

--- a/src/services/events.service.ts
+++ b/src/services/events.service.ts
@@ -1,0 +1,23 @@
+import { ZodFormattedError } from '../../deps.ts';
+
+import { EventMode } from '../models/event.model.ts';
+import { ErrorResponse } from './general.service.ts';
+
+// getAllEvents
+
+export type GetAllEventsSuccessResponse = Event[];
+
+export type GetAllEventsErrorResponse = {
+  error: string;
+  details: ZodFormattedError<{ mode?: EventMode}> | undefined;
+};
+
+export type GetAllEventsResponse =
+  | GetAllEventsSuccessResponse
+  | GetAllEventsErrorResponse;
+
+// getEventById
+
+export type GetEventByIdSuccessResponse = Event;
+
+export type GetEventByIdResponse = GetEventByIdSuccessResponse | ErrorResponse;

--- a/src/services/general.service.ts
+++ b/src/services/general.service.ts
@@ -1,0 +1,11 @@
+// general use
+
+export type MessageResponse = {
+  message: string;
+};
+
+export type ErrorResponse = {
+  error: string;
+};
+
+export type GeneralResponse = MessageResponse | ErrorResponse;

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -1,0 +1,8 @@
+import { SafeUser } from '../models/user.model.ts';
+import { ErrorResponse } from './general.service.ts';
+
+// getAllUsers
+
+export type GetAllUsersSuccessResponse = SafeUser[];
+
+export type GetAllUsersResponse = GetAllUsersSuccessResponse | ErrorResponse;


### PR DESCRIPTION
### ✨ What’s Changed?

Added all of the API type uses to shared, for both frontend and backend to match with body.

### 📚 Related Issues

None

### ✅ Checklist

- [x] Lint passes (`deno task lint`)
- [x] Code is formatted (`deno task fmt`)
- [x] No type errors (`deno check .`)
